### PR TITLE
Add support for CLI parameters (--numbers, --special, --uppercase)

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ const arguments_processing_array = [
     arg_name: "length",
     arg_length: 2,
     arg_handler_func: process_length_arg,
-    arg_helper_message: `Specify the length of the password (>=${DEFAULT_PASSWORD_LENGTH}, def.${DEFAULT_PASSWORD_LENGTH}, max.${MAX_PASSWORD_LENGTH}).\n`,
+    arg_helper_message: `Specify the password length <number> (>=${DEFAULT_PASSWORD_LENGTH}, def.${DEFAULT_PASSWORD_LENGTH}, max.${MAX_PASSWORD_LENGTH}).\n`,
     arg_processed: false,
   },
   {
@@ -46,7 +46,7 @@ const arguments_processing_array = [
     arg_name: "uppercase",
     arg_length: 1,
     arg_handler_func: process_single_arg,
-    arg_helper_message: "Can include uppercase characters.\n",
+    arg_helper_message: "Password will include uppercase characters.\n",
     arg_processed: false,
     arg_set: DEFAULT_PASSWORD_CHARS.toUpperCase(),
     arg_set_char_count: 0,
@@ -56,7 +56,7 @@ const arguments_processing_array = [
     arg_name: "numbers",
     arg_length: 1,
     arg_handler_func: process_single_arg,
-    arg_helper_message: "Can include numbers as well.\n",
+    arg_helper_message: "Password will include numbers as well.\n",
     arg_processed: false,
     arg_set: NUMBERS,
     arg_set_char_count: 0,
@@ -66,7 +66,7 @@ const arguments_processing_array = [
     arg_name: "special",
     arg_length: 1,
     arg_handler_func: process_single_arg,
-    arg_helper_message: `Can include special characters ${SPECIAL_CHARS} as well.\n`,
+    arg_helper_message: `Include special characters ${SPECIAL_CHARS} as well.\n`,
     arg_processed: false,
     arg_set: SPECIAL_CHARS,
     arg_set_char_count: 0,
@@ -171,6 +171,78 @@ function generate_password(password_length, password_valid_chars) {
   return new_password;
 }
 
+// this function will ensure that the password contains
+// at least one character from each optional set (num, upper, spec)
+function ensure_optional_characters(password) {
+  // we need to track the positions of optional characters in the password
+  // the set will contain the positions of the optional characters
+  const filled_optional_chars = new Set();
+
+  // scroll through the password to count optional characters
+  for (let i = 0; i < password.length; i++) {
+    const char = password[i];
+
+    // check if the character belongs to any optional arg_set
+    arguments_processing_array.forEach((arg) => {
+      if (arg.arg_set && arg.arg_set.includes(char)) {
+        // increase the count for this character set
+        arg.arg_set_char_count++;
+        // remember the position of the optional character
+        filled_optional_chars.add(i);
+      }
+    });
+  }
+
+  //   console.log("filled optional character positions:", filled_optional_chars);
+  //   arguments_processing_array.forEach((arg) => {
+  //     if (arg.arg_set) {
+  //       console.log(`count for ${arg.arg_name}: ${arg.arg_set_char_count}`);
+  //     }
+  //   });
+
+  // convert to array (easier to replace chars)
+  let new_password = password.split("");
+
+  // scroll through arguments_processing_array again
+  // to check the count of optional characters, add if needed
+  // we need at least one character from each optional set
+  // (this only in case the corresponding argument was set)
+  // arg.arg_processed is true if the argument was set at the program run
+  arguments_processing_array.forEach((arg) => {
+    if (arg.arg_set && arg.arg_processed && arg.arg_set_char_count === 0) {
+      // Generate a missing character and find a position for it to replace
+      while (true) {
+        // 1. generate a random position in the password
+        const random_position = Math.floor(Math.random() * password.length);
+
+        // 2. ensure the position is not already taken
+        if (!filled_optional_chars.has(random_position)) {
+          // Generate a random character from the missing set
+          const missing_char = arg.arg_set.charAt(
+            Math.floor(Math.random() * arg.arg_set.length)
+          );
+
+          // 3. replace the character at the selected position
+          new_password[random_position] = missing_char;
+
+          // 4. add the position to filled_optional_chars (mark as taken)
+          filled_optional_chars.add(random_position);
+
+          //   console.log(
+          //     `R\replaced char at pos. ${random_position} with "${missing_char}" for set "${arg.arg_name}"`
+          //   );
+
+          // replacement is done, break the loop
+          break;
+        }
+      }
+    }
+  });
+
+  // back to string and return
+  return new_password.join("");
+}
+
 let password_length = DEFAULT_PASSWORD_LENGTH;
 let password_chars = DEFAULT_PASSWORD_CHARS;
 
@@ -182,6 +254,8 @@ console.log("(run with --help to see available options)\n");
 
 console.log("---> password_length    ---> " + password_length + " characters");
 const generated_password = generate_password(password_length, password_chars);
-console.log("---> generated password ---> " + generated_password);
+console.log("--->           password ---> " + generated_password);
+const updated_password = ensure_optional_characters(generated_password);
+console.log("---> generated password ---> " + updated_password);
 
 process.exit(0);

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ const process = require("process");
 const APP_VERSION = "0.0.2";
 const DEFAULT_ARG_PREFIXES = ["--", "-", "/"];
 const DEFAULT_PASSWORD_CHARS = "abcdefghijklmnopqrstuvwxyz";
+const NUMBERS = "0123456789";
+const SPECIAL_CHARS = "!@#$%^&*()_+[]?~\\/{}";
 const DEFAULT_PASSWORD_LENGTH = 8;
 const MAX_PASSWORD_LENGTH = 64;
 
@@ -28,7 +30,7 @@ const arguments_processing_array = [
     arg_name: "help",
     arg_length: 1,
     arg_handler_func: process_help_arg,
-    arg_helper_message: "Show this help message.",
+    arg_helper_message: "Show this help message.\n",
     arg_processed: false,
   },
   {
@@ -36,22 +38,41 @@ const arguments_processing_array = [
     arg_name: "length",
     arg_length: 2,
     arg_handler_func: process_length_arg,
-    arg_helper_message: `Specify the length of the password (>=${DEFAULT_PASSWORD_LENGTH}, def.${DEFAULT_PASSWORD_LENGTH}, max.${MAX_PASSWORD_LENGTH}).`,
+    arg_helper_message: `Specify the length of the password (>=${DEFAULT_PASSWORD_LENGTH}, def.${DEFAULT_PASSWORD_LENGTH}, max.${MAX_PASSWORD_LENGTH}).\n`,
     arg_processed: false,
   },
   {
     arg_flags: ["uppercase", "upper", "u"],
     arg_name: "uppercase",
     arg_length: 1,
-    arg_handler_func: process_uppercase_arg,
-    arg_helper_message: `Use uppercase characters as well.`,
+    arg_handler_func: process_single_arg,
+    arg_helper_message: "Can include uppercase characters.\n",
     arg_processed: false,
     arg_set: DEFAULT_PASSWORD_CHARS.toUpperCase(),
     arg_set_char_count: 0,
   },
+  {
+    arg_flags: ["numbers", "num", "n"],
+    arg_name: "numbers",
+    arg_length: 1,
+    arg_handler_func: process_single_arg,
+    arg_helper_message: "Can include numbers as well.\n",
+    arg_processed: false,
+    arg_set: NUMBERS,
+    arg_set_char_count: 0,
+  },
+  {
+    arg_flags: ["special", "spec", "s"],
+    arg_name: "special",
+    arg_length: 1,
+    arg_handler_func: process_single_arg,
+    arg_helper_message: `Can include special characters ${SPECIAL_CHARS} as well.\n`,
+    arg_processed: false,
+    arg_set: SPECIAL_CHARS,
+    arg_set_char_count: 0,
+  },
 ];
 
-// function to process help argument
 function process_help_arg() {
   console.log("\nUsage: npm run passgen [options]\n");
 
@@ -67,7 +88,7 @@ function process_help_arg() {
 }
 
 // function to process length argument
-function process_length_arg(passed_arguments, index) {
+function process_length_arg(passed_arguments, index, agr_array_index) {
   // check if there is a next argument
   const next_arg = passed_arguments[index + 1];
   if (!next_arg) {
@@ -87,17 +108,13 @@ function process_length_arg(passed_arguments, index) {
   password_length = length;
 }
 
-function process_uppercase_arg() {
-  console.log("Uppercase message");
-  const arg_array_index = arguments_processing_array.find(
-    (arg) => arg.arg_name === "uppercase"
-  );
-  console.log(arg_array_index);
+function process_single_arg(passed_arguments, index, arg_array_index) {
+  //   console.log(arg_array_index);
   password_chars += arg_array_index.arg_set;
 }
 
 function analyze_program_arguments(passed_arguments) {
-  // console.log("Processing arguments");
+  //   console.log("Processing arguments");
   // loop through all program arguments
   for (let i = 0; i < passed_arguments.length; ) {
     const arg = passed_arguments[i];
@@ -118,7 +135,7 @@ function analyze_program_arguments(passed_arguments) {
           // this is where we call the handler function for the argument
           // it is responsible for processing the argument
           argument.arg_processed = true;
-          argument.arg_handler_func(passed_arguments, i);
+          argument.arg_handler_func(passed_arguments, i, argument);
         }
         is_recognized = true;
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 // new version of password generator, with command line arguments
 const process = require("process");
 
-const APP_VERSION = "2.0.0";
-const DEFAILT_ARG_PREFIXES = ["--", "-", "/"];
+const APP_VERSION = "0.0.2";
+const DEFAULT_ARG_PREFIXES = ["--", "-", "/"];
 const DEFAULT_PASSWORD_CHARS = "abcdefghijklmnopqrstuvwxyz";
 const DEFAULT_PASSWORD_LENGTH = 8;
 const MAX_PASSWORD_LENGTH = 64;
@@ -39,6 +39,16 @@ const arguments_processing_array = [
     arg_helper_message: `Specify the length of the password (>=${DEFAULT_PASSWORD_LENGTH}, def.${DEFAULT_PASSWORD_LENGTH}, max.${MAX_PASSWORD_LENGTH}).`,
     arg_processed: false,
   },
+  {
+    arg_flags: ["uppercase", "upper", "u"],
+    arg_name: "uppercase",
+    arg_length: 1,
+    arg_handler_func: process_uppercase_arg,
+    arg_helper_message: `Use uppercase characters as well.`,
+    arg_processed: false,
+    arg_set: DEFAULT_PASSWORD_CHARS.toUpperCase(),
+    arg_set_char_count: 0,
+  },
 ];
 
 // function to process help argument
@@ -46,7 +56,7 @@ function process_help_arg() {
   console.log("\nUsage: npm run passgen [options]\n");
 
   arguments_processing_array.forEach((argument) => {
-    const possible_flags = DEFAILT_ARG_PREFIXES.map((prefix) =>
+    const possible_flags = DEFAULT_ARG_PREFIXES.map((prefix) =>
       argument.arg_flags.map((flag) => prefix + flag).join(", ")
     ).join(", ");
     console.log(possible_flags);
@@ -77,31 +87,43 @@ function process_length_arg(passed_arguments, index) {
   password_length = length;
 }
 
-// function to process arguments
+function process_uppercase_arg() {
+  console.log("Uppercase message");
+  const arg_array_index = arguments_processing_array.find(
+    (arg) => arg.arg_name === "uppercase"
+  );
+  console.log(arg_array_index);
+  password_chars += arg_array_index.arg_set;
+}
+
 function analyze_program_arguments(passed_arguments) {
   // console.log("Processing arguments");
-  // loop through all arguments
+  // loop through all program arguments
   for (let i = 0; i < passed_arguments.length; ) {
     const arg = passed_arguments[i];
     let is_recognized = false;
 
     // for each argument, check if it is recognized
+    // we look through all arguments_processing_array objects
     for (const argument of arguments_processing_array) {
       if (
         argument.arg_flags.some((flag) =>
-          DEFAILT_ARG_PREFIXES.some((prefix) => arg === prefix + flag)
+          DEFAULT_ARG_PREFIXES.some((prefix) => arg === prefix + flag)
         )
       ) {
-        // if was already processed, display error message (no duplicates)
+        // check if the argument is already processed, do not allow duplicates
         if (argument.arg_processed) {
           display_error_message("argument_duplicate", argument.arg_name);
         } else {
+          // this is where we call the handler function for the argument
+          // it is responsible for processing the argument
           argument.arg_processed = true;
           argument.arg_handler_func(passed_arguments, i);
         }
         is_recognized = true;
 
         // increment i by the number of parts of the argument (1+) to skip them
+        // currently is it only for the length argument
         i += argument.arg_length;
         break;
       }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
+// new version of password generator, with command line arguments
 const process = require("process");
 
-const APP_VERSION = "1.0.0";
+const APP_VERSION = "2.0.0";
 const DEFAILT_ARG_PREFIXES = ["--", "-", "/"];
 const DEFAULT_PASSWORD_CHARS = "abcdefghijklmnopqrstuvwxyz";
 const DEFAULT_PASSWORD_LENGTH = 8;


### PR DESCRIPTION
Added support for optional character sets in password generation:

1. Uppercase letters (--uppercase)
2. Numbers (--numbers)
3. Special characters (--special)

Ensured that at least one character from each chosen set will appear in the password (if the corresponding option is selected).
